### PR TITLE
Fixed Constructor/Method Name FPDF

### DIFF
--- a/inc/fpdf/fpdf.php
+++ b/inc/fpdf/fpdf.php
@@ -72,7 +72,7 @@ class FPDF {
 *                               Public methods                                 *
 *                                                                              *
 *******************************************************************************/
-function FPDF($orientation='P', $unit='mm', $size='A4')
+function FPDFMETHOD($orientation='P', $unit='mm', $size='A4')
 {
 	// Some checks
 	$this->_dochecks();

--- a/phpinvoice.php
+++ b/phpinvoice.php
@@ -52,7 +52,7 @@ class phpinvoice extends FPDF_rotation  {
 		$this->setLanguage($language);
 		$this->setDocumentSize($size);
 		$this->setColor("#222222");
-		$this->FPDF('P','mm',array($this->document['w'],$this->document['h']));
+		$this->FPDFMETHOD('P','mm',array($this->document['w'],$this->document['h']));
 		$this->AliasNbPages();
 		$this->SetMargins($this->margins['l'],$this->margins['t'],$this->margins['r']);
 	}


### PR DESCRIPTION
Newer Versions of PHP Doesn't support constructor/class same name.