### PR TITLE
Add a return statement to ::render()

### DIFF
--- a/phpinvoice.php
+++ b/phpinvoice.php
@@ -329,7 +329,7 @@ class phpinvoice extends FPDF_rotation  {
         $this->AddPage();
         $this->Body();
         $this->AliasNbPages();
-        $this->Output($name,$destination);
+        return $this->Output($name,$destination);
     }
 
     public function Body() {


### PR DESCRIPTION
The "S" parameter doesn't work without the /return/ statement. You need it to get the buffer's value from FPDF.