### PR TITLE
Fix wrong column number when having discount but not VAT.

### DIFF
--- a/src/InvoicePrinter.php
+++ b/src/InvoicePrinter.php
@@ -623,7 +623,7 @@ class InvoicePrinter extends FPDF
         $this->SetFont($this->font, '', 8);
         $this->SetTextColor(50, 50, 50);
         $this->Cell(0, 10, $this->footernote, 0, 0, 'L');
-        $this->Cell(0, 10, $this->lang['page'] . ' ' . $this->PageNo() . ' ' . $this->lang['page_of'] . ' {nb}', 0, 0,
+        $this->Cell(0, 10, iconv('UTF-8', 'ISO-8859-1', $this->lang['page']) . ' ' . $this->PageNo() . ' ' . $this->lang['page_of'] . ' {nb}', 0, 0,
             'R');
     }
 

--- a/src/InvoicePrinter.php
+++ b/src/InvoicePrinter.php
@@ -46,13 +46,14 @@ class InvoicePrinter extends FPDF
     public $dimensions;
     public $display_tofrom = true;
 
+    protected $columns;
+
     /******************************************
      * Class Constructor                     *
      * param : Page Size , Currency, Language *
      ******************************************/
     public function __construct($size = 'A4', $currency = '$', $language = 'en')
     {
-        $this->columns            = 4;
         $this->items              = [];
         $this->totals             = [];
         $this->addText            = [];
@@ -62,6 +63,8 @@ class InvoicePrinter extends FPDF
         $this->setLanguage($language);
         $this->setDocumentSize($size);
         $this->setColor("#222222");
+
+        $this->recalculateColumns();
 
         parent::__construct('P', 'mm', [$this->document['w'], $this->document['h']]);
 
@@ -236,7 +239,7 @@ class InvoicePrinter extends FPDF
                         $this->referenceformat[1]);
             }
             $this->vatField = true;
-            $this->columns  = 5;
+            $this->recalculateColumns();
         }
         $p['quantity'] = $quantity;
         $p['price']    = $price;
@@ -250,7 +253,7 @@ class InvoicePrinter extends FPDF
                         $this->referenceformat[1]);
             }
             $this->discountField = true;
-            $this->columns       = 6;
+            $this->recalculateColumns();
         }
         $this->items[] = $p;
     }
@@ -654,6 +657,18 @@ class InvoicePrinter extends FPDF
             $this->_out('Q');
         }
         parent::_endpage();
+    }
+
+
+    private function recalculateColumns()
+    {
+        $this->columns = 4;
+
+        if (isset($this->vatField))
+            $this->columns += 1;
+
+        if (isset($this->discountField))
+            $this->columns += 1;
     }
 
 }


### PR DESCRIPTION
Hi there!

I noticed that when adding items with discount but without VAT, the table layout breaks itself:
<img width="716" alt="screen shot 2018-08-07 at 13 49 35" src="https://user-images.githubusercontent.com/6589559/43774346-0d0f5a48-9a49-11e8-8083-f8b461175cca.png">

My solution was to recalculate the column number every time a VAT/discount is set instead of resetting it to a fixed number:

<img width="704" alt="screen shot 2018-08-07 at 13 50 30" src="https://user-images.githubusercontent.com/6589559/43774397-38b11f9c-9a49-11e8-95fc-e3498abbeb68.png">
